### PR TITLE
fix(slides): reduce whitespace in new IBM Roles and Persona Reviewers slides

### DIFF
--- a/src/components/slides/Slide04RolesIbm.svelte
+++ b/src/components/slides/Slide04RolesIbm.svelte
@@ -100,7 +100,7 @@
     padding: var(--spacing-2xl) var(--spacing-content);
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-md);
+    gap: var(--spacing-lg);
   }
 
   .slide-header { text-align: center; }
@@ -143,16 +143,16 @@
     display: flex;
     align-items: flex-start;
     gap: var(--spacing-md);
-    padding: var(--spacing-sm) var(--spacing-lg);
+    padding: var(--spacing-md) var(--spacing-xl);
   }
 
-  .thesis-icon { font-size: 1.3rem; flex-shrink: 0; margin-top: 2px; }
+  .thesis-icon { font-size: 1.5rem; flex-shrink: 0; margin-top: 2px; }
 
   .thesis p {
-    font-size: 0.85rem;
+    font-size: 0.95rem;
     color: var(--color-neutral-light);
-    opacity: 0.85;
-    line-height: 1.55;
+    opacity: 0.88;
+    line-height: 1.6;
     margin-bottom: 0;
     font-style: italic;
   }
@@ -163,36 +163,37 @@
   .roles-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: var(--spacing-sm);
+    gap: var(--spacing-md);
   }
 
   .role {
     display: flex;
     align-items: flex-start;
-    gap: var(--spacing-sm);
-    padding: var(--spacing-sm) var(--spacing-md);
+    gap: var(--spacing-md);
+    padding: var(--spacing-md) var(--spacing-lg);
+    min-height: 96px;
   }
 
-  .role-icon { font-size: 1.3rem; flex-shrink: 0; margin-top: 1px; }
+  .role-icon { font-size: 1.5rem; flex-shrink: 0; margin-top: 1px; }
 
   .role-body {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 4px;
   }
 
   .role-name {
     font-family: var(--font-display);
-    font-size: 0.9rem;
+    font-size: 1rem;
     font-weight: 800;
     color: var(--color-neutral-light);
   }
 
   .role-desc {
-    font-size: 0.7rem;
+    font-size: 0.78rem;
     color: var(--color-neutral-light);
-    opacity: 0.65;
-    line-height: 1.4;
+    opacity: 0.72;
+    line-height: 1.5;
   }
 
   /* Levers */
@@ -211,14 +212,14 @@
   .levers-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: var(--spacing-sm);
+    gap: var(--spacing-md);
   }
 
   .lever {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    padding: var(--spacing-sm) var(--spacing-md);
+    gap: 6px;
+    padding: var(--spacing-md) var(--spacing-lg);
     background: rgba(30, 58, 138, 0.18);
     border: 1px solid rgba(96, 165, 250, 0.15);
     border-radius: var(--radius-sm);
@@ -240,7 +241,7 @@
 
   .lever-name {
     font-family: var(--font-display);
-    font-size: 0.82rem;
+    font-size: 0.92rem;
     font-weight: 700;
     color: var(--color-neutral-light);
     flex: 1;
@@ -274,10 +275,10 @@
   }
 
   .lever-desc {
-    font-size: 0.7rem;
+    font-size: 0.78rem;
     color: var(--color-neutral-light);
-    opacity: 0.7;
-    line-height: 1.45;
+    opacity: 0.72;
+    line-height: 1.5;
   }
 
   /* Bottom insight */
@@ -285,19 +286,19 @@
     display: flex;
     align-items: flex-start;
     gap: var(--spacing-md);
-    padding: var(--spacing-md) var(--spacing-lg);
+    padding: var(--spacing-lg) var(--spacing-xl);
     background: rgba(59, 130, 246, 0.08);
     border: 1px solid rgba(96, 165, 250, 0.2);
     border-radius: var(--radius-sm);
   }
 
-  .insight-icon { font-size: 1.1rem; flex-shrink: 0; margin-top: 1px; }
+  .insight-icon { font-size: 1.3rem; flex-shrink: 0; margin-top: 1px; }
 
   .bottom-insight p {
-    font-size: 0.85rem;
+    font-size: 0.95rem;
     color: var(--color-neutral-light);
-    opacity: 0.85;
-    line-height: 1.55;
+    opacity: 0.88;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 

--- a/src/components/slides/Slide14PersonaReviewers.svelte
+++ b/src/components/slides/Slide14PersonaReviewers.svelte
@@ -123,7 +123,7 @@
     padding: var(--spacing-2xl) var(--spacing-content);
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-md);
+    gap: var(--spacing-lg);
   }
 
   .slide-header { text-align: center; }
@@ -164,7 +164,7 @@
   /* Quote */
   .quote-block {
     position: relative;
-    padding: var(--spacing-sm) var(--spacing-xl);
+    padding: var(--spacing-md) var(--spacing-2xl);
     background: rgba(167, 139, 250, 0.06);
     border-left: 3px solid #a78bfa;
     border-radius: var(--radius-sm);
@@ -182,10 +182,10 @@
   }
 
   .quote-block p {
-    font-size: 0.9rem;
+    font-size: 1rem;
     color: var(--color-neutral-light);
-    opacity: 0.88;
-    line-height: 1.55;
+    opacity: 0.9;
+    line-height: 1.6;
     margin-bottom: 0;
     font-style: italic;
   }
@@ -202,8 +202,9 @@
   .source {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-sm);
-    padding: var(--spacing-md) var(--spacing-lg);
+    gap: var(--spacing-md);
+    padding: var(--spacing-lg);
+    min-height: 200px;
   }
 
   .source-head {
@@ -262,11 +263,12 @@
   }
 
   .source-claim {
-    font-size: 0.78rem;
+    font-size: 0.85rem;
     color: var(--color-neutral-light);
-    opacity: 0.82;
-    line-height: 1.5;
+    opacity: 0.85;
+    line-height: 1.6;
     margin-bottom: 0;
+    flex: 1;
   }
 
   .source-origin {
@@ -300,11 +302,12 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 4px;
-    padding: var(--spacing-sm) var(--spacing-md);
+    gap: 6px;
+    padding: var(--spacing-md) var(--spacing-lg);
     background: rgba(30, 58, 138, 0.18);
     border: 1px solid rgba(96, 165, 250, 0.15);
     border-radius: var(--radius-sm);
+    min-height: 120px;
   }
 
   .flow-step {
@@ -314,20 +317,20 @@
     opacity: 0.7;
   }
 
-  .flow-icon { font-size: 1.2rem; }
+  .flow-icon { font-size: 1.4rem; }
 
   .flow-name {
     font-family: var(--font-display);
-    font-size: 0.82rem;
+    font-size: 0.92rem;
     font-weight: 700;
     color: var(--color-neutral-light);
   }
 
   .flow-desc {
-    font-size: 0.68rem;
+    font-size: 0.78rem;
     color: var(--color-neutral-light);
-    opacity: 0.7;
-    line-height: 1.4;
+    opacity: 0.72;
+    line-height: 1.5;
   }
 
   .flow-arrow {
@@ -347,19 +350,19 @@
     display: flex;
     align-items: flex-start;
     gap: var(--spacing-md);
-    padding: var(--spacing-md) var(--spacing-lg);
+    padding: var(--spacing-lg) var(--spacing-xl);
     background: rgba(59, 130, 246, 0.08);
     border: 1px solid rgba(96, 165, 250, 0.2);
     border-radius: var(--radius-sm);
   }
 
-  .insight-icon { font-size: 1.1rem; flex-shrink: 0; margin-top: 1px; }
+  .insight-icon { font-size: 1.3rem; flex-shrink: 0; margin-top: 1px; }
 
   .bottom-insight p {
-    font-size: 0.85rem;
+    font-size: 0.95rem;
     color: var(--color-neutral-light);
-    opacity: 0.85;
-    line-height: 1.55;
+    opacity: 0.88;
+    line-height: 1.6;
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
## Summary

Tras mergear PR #1 me confirmaste que los slides nuevos tenían demasiado espacio en blanco. Verificado: en viewport 1440×900 el Slide 4 (Roles IBM) ocupa solo 473 de 900 px, el Slide 14 (Persona Reviewers) 495.

Sin reestructurar el layout, denso los dos slides:

**Slide 4 · Roles IBM**
- Tarjetas de los 7 roles con \`min-height: 96px\` y padding \`md/lg\`
- 4 palancas: padding \`md/lg\`, gap interno mayor
- Fuentes: \`role-name\` 0.9→1rem, \`role-desc\` 0.7→0.78rem, \`lever-name\` 0.82→0.92rem, \`lever-desc\` 0.7→0.78rem
- Resultado: 473 → **564px** (gap 336)

**Slide 14 · Persona Reviewers**
- Tarjetas de fuentes con \`min-height: 200px\` y \`source-claim\` con \`flex: 1\` para llenar
- Pasos del flow con \`min-height: 120px\` y padding \`md/lg\`
- Fuentes: \`source-claim\` 0.78→0.85rem, \`flow-name\` 0.82→0.92rem, \`flow-desc\` 0.68→0.78rem, quote 0.9→1rem
- Resultado: 495 → **597px** (gap 303)

## Test plan

- [x] \`pnpm exec astro check\` → 0/0/0 sobre 8 ficheros (con \`dist/\` limpio).
- [x] \`pnpm exec astro build\` → 1.42s, 1 página.
- [x] Verificación visual a 1440×900 con preview del dev server.
- [ ] Cross-check en mobile/tablet — los breakpoints existentes ya cubren 900/768/480/390, conviene confirmar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)